### PR TITLE
ci: bump the  action versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,12 @@ runs:
   using: composite
   steps:
     - name: Checkout action other repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Check Jira ID or Skip tag
-      uses: gsactions/commit-message-checker@v1
+      uses: gsactions/commit-message-checker@v2
       id: jira-id
       with:
         pattern: (?:ed-[\d]+)|(?:(?:skip|no) issue)|dependabot
@@ -33,7 +33,7 @@ runs:
       run: git clone https://github.com/area28technologies/commitlint.git
 
     - name: Check conventional commits
-      uses: wagoid/commitlint-github-action@v4
+      uses: wagoid/commitlint-github-action@v5
       id: conventional-commitlint
       with:
         configFile: commitlint/commitlint.config.cjs


### PR DESCRIPTION
ED-808 , the new actions versions donot use node version 12 

[ED-808]: https://area28.atlassian.net/browse/ED-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ